### PR TITLE
Reorder calls

### DIFF
--- a/minos/networks/handler/command/services.py
+++ b/minos/networks/handler/command/services.py
@@ -64,8 +64,8 @@ class MinosCommandPeriodicService(PeriodicService):
 
         :return: This method does not return anything.
         """
-        await super().start()
         await self.dispatcher.setup()
+        await super().start()
 
     async def callback(self) -> None:
         """Method to be called periodically by the internal ``aiomisc`` logic.

--- a/minos/networks/handler/command_reply/services.py
+++ b/minos/networks/handler/command_reply/services.py
@@ -64,8 +64,8 @@ class MinosCommandReplyPeriodicService(PeriodicService):
 
         :return: This method does not return anything.
         """
-        await super().start()
         await self.dispatcher.setup()
+        await super().start()
 
     async def callback(self) -> None:
         """Method to be called periodically by the internal ``aiomisc`` logic.

--- a/minos/networks/handler/event/services.py
+++ b/minos/networks/handler/event/services.py
@@ -64,8 +64,8 @@ class MinosEventPeriodicService(PeriodicService):
 
         :return: This method does not return anything.
         """
-        await super().start()
         await self.dispatcher.setup()
+        await super().start()
 
     async def callback(self) -> None:
         """Method to be called periodically by the internal ``aiomisc`` logic.


### PR DESCRIPTION
The setup method must be called before the start of the service. #132