### PR TITLE
Extend RestBuilder from MinosSetup

### DIFF
--- a/minos/networks/rest/builders.py
+++ b/minos/networks/rest/builders.py
@@ -11,11 +11,12 @@ from aiohttp import (
 
 from minos.common import (
     MinosConfig,
+    MinosSetup,
     import_module,
 )
 
 
-class RestBuilder:
+class RestBuilder(MinosSetup):
     """
     Rest Interface Handler
 
@@ -25,7 +26,8 @@ class RestBuilder:
 
     __slots__ = "_config", "_app"
 
-    def __init__(self, config: MinosConfig, app: web.Application = web.Application()):
+    def __init__(self, config: MinosConfig, app: web.Application = web.Application(), **kwargs):
+        super().__init__(**kwargs)
         self._config = config
         self._app = app
         self.load_routes()

--- a/minos/networks/rest/builders.py
+++ b/minos/networks/rest/builders.py
@@ -32,6 +32,10 @@ class RestBuilder(MinosSetup):
         self._app = app
         self.load_routes()
 
+    @classmethod
+    def _from_config(cls, *args, config: MinosConfig, **kwargs):
+        return cls(*args, config=config, **kwargs)
+
     def load_routes(self):
         """Load routes from config file."""
         for item in self._config.rest.endpoints:

--- a/minos/networks/rest/services.py
+++ b/minos/networks/rest/services.py
@@ -5,7 +5,6 @@ This file is part of minos framework.
 
 Minos framework can not be copied and/or distributed without the express permission of Clariteia SL.
 """
-import typing as t
 
 from aiomisc.service.aiohttp import (
     AIOHTTPService,
@@ -28,12 +27,11 @@ class RestService(AIOHTTPService):
 
     """
 
-    def __init__(self, config: MinosConfig, **kwds: t.Any):
+    def __init__(self, config: MinosConfig, **kwargs):
         address = config.rest.broker.host
         port = config.rest.broker.port
-        super().__init__(address=address, port=port, **kwds)
-        self._config = config
-        self.rest = RestBuilder(config=self._config)
+        super().__init__(address=address, port=port, **kwargs)
+        self.rest = RestBuilder.from_config(config=config, **kwargs)
 
     async def create_application(self):
         return self.rest.get_app()  # pragma: no cover

--- a/tests/test_networks/test_rest/test_builders.py
+++ b/tests/test_networks/test_rest/test_builders.py
@@ -1,0 +1,25 @@
+from minos.common import (
+    MinosConfig,
+)
+from minos.common.testing import (
+    PostgresAsyncTestCase,
+)
+from minos.networks import (
+    RestBuilder,
+)
+from tests.utils import (
+    BASE_PATH,
+)
+
+
+class TestRestService(PostgresAsyncTestCase):
+    CONFIG_FILE_PATH = BASE_PATH / "test_config.yml"
+
+    def test_from_config(self):
+        config = MinosConfig(self.CONFIG_FILE_PATH)
+        dispatcher = RestBuilder.from_config(config=config)
+        self.assertIsInstance(dispatcher, RestBuilder)
+
+    def test_from_config_raises(self):
+        with self.assertRaises(Exception):
+            RestBuilder.from_config()


### PR DESCRIPTION
minos.networks.RestBuilder must extend minos.common.MinosSetup and be constructed calling from_config #166